### PR TITLE
Inject the Jekyll Site payload into the Liquid render attributes

### DIFF
--- a/features/fixtures/_includes/base-url.html
+++ b/features/fixtures/_includes/base-url.html
@@ -1,0 +1,1 @@
+<img src="{{ site.baseurl }}/{{ path }}">

--- a/features/responsive-image-block.feature
+++ b/features/responsive-image-block.feature
@@ -19,6 +19,22 @@ Feature: Jekyll responsive_image_block tag
     When I run Jekyll
     Then I should see "<img alt=\"Lorem ipsum\" src=\"/assets/test.png\" title=\"Magic rainbow adventure!\"" in "_site/index.html"
 
+  Scenario: Global variables available in templates
+    Given I have a file "index.html" with:
+      """
+      {% responsive_image_block %}
+          path: assets/test.png
+      {% endresponsive_image_block %}
+      """
+    And I have a configuration with:
+      """
+        baseurl: https://wildlyinaccurate.com
+        responsive_image:
+          template: _includes/base-url.html
+      """
+    When I run Jekyll
+    Then I should see "<img src=\"https://wildlyinaccurate.com/assets/test.png\">" in "_site/index.html"
+
   Scenario: More complex logic in the block tag
     Given I have a responsive_image configuration with "template" set to "_includes/responsive-image.html"
     And I have a file "index.html" with:

--- a/features/responsive-image-tag.feature
+++ b/features/responsive-image-tag.feature
@@ -9,6 +9,17 @@ Feature: Jekyll responsive_image tag
     When I run Jekyll
     Then I should see "<img alt=\"Foobar\" src=\"/assets/test.png\"" in "_site/index.html"
 
+  Scenario: Global variables available in templates
+    Given I have a file "index.html" with "{% responsive_image path: assets/test.png %}"
+    And I have a configuration with:
+      """
+        baseurl: https://wildlyinaccurate.com
+        responsive_image:
+          template: _includes/base-url.html
+      """
+    When I run Jekyll
+    Then I should see "<img src=\"https://wildlyinaccurate.com/assets/test.png\">" in "_site/index.html"
+
   Scenario: Adding custom attributes
     Given I have a responsive_image configuration with "template" set to "_includes/responsive-image.html"
     And I have a file "index.html" with:

--- a/features/step_definitions/jekyll_steps.rb
+++ b/features/step_definitions/jekyll_steps.rb
@@ -8,6 +8,10 @@ Then /^Jekyll should throw a "(.+)"$/ do |error_class|
   assert_raise(Object.const_get(error_class)) { run_jekyll }
 end
 
+Given /^I have a configuration with:$/ do |config|
+  write_file('_config.yml', config)
+end
+
 Given /^I have a responsive_image configuration with:$/ do |config|
   write_file('_config.yml', "responsive_image:\n#{config}")
 end

--- a/lib/jekyll/responsive_image/block.rb
+++ b/lib/jekyll/responsive_image/block.rb
@@ -4,7 +4,8 @@ module Jekyll
       include Jekyll::ResponsiveImage::Common
 
       def render(context)
-        config = make_config(context.registers[:site])
+        site = context.registers[:site]
+        config = make_config(site)
 
         attributes = YAML.load(super)
         image_template = attributes['template'] || config['template']
@@ -16,7 +17,7 @@ module Jekyll
         partial = File.read(image_template)
         template = Liquid::Template.parse(partial)
 
-        template.render!(attributes)
+        template.render!(attributes.merge(site.site_payload))
       end
     end
   end

--- a/lib/jekyll/responsive_image/tag.rb
+++ b/lib/jekyll/responsive_image/tag.rb
@@ -15,7 +15,8 @@ module Jekyll
       end
 
       def render(context)
-        config = make_config(context.registers[:site])
+        site = context.registers[:site]
+        config = make_config(site)
 
         image = ImageProcessor.process(@attributes['path'], config)
         @attributes['original'] = image[:original]
@@ -26,7 +27,7 @@ module Jekyll
         partial = File.read(image_template)
         template = Liquid::Template.parse(partial)
 
-        template.render!(@attributes)
+        template.render!(@attributes.merge(site.site_payload))
       end
     end
   end


### PR DESCRIPTION
This enables the use of `site` and `jekyll` variables.