### PR TITLE
Managing base path to file in resized versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ responsive_image:
     - width: 1400
       quality: 90
 
+  # [Optional, Default: assets]
+  # Use this parameter if your images are stored in subfolders
+  # and you want to keep the folder arrangement through the process
+  base_path: assets
+
   # [Optional, Default: assets/resized/%{filename}-%{width}x%{height}.%{extension}]
   # The template used when generating filenames for resized images. Must be a
   # relative path.
@@ -52,6 +57,7 @@ responsive_image:
   # Parameters available are:
   #   %{basename}    Basename of the file (assets/some-file.jpg => some-file.jpg)
   #   %{filename}    Basename without the extension (assets/some-file.jpg => some-file)
+  #   %{folderpath}    Relative path from the image asset folder to the the file (`assets/somefolder/some-file.jpg` => `somefolder`)
   #   %{extension}   Extension of the file (assets/some-file.jpg => jpg)
   #   %{width}       Width of the resized image
   #   %{height}      Height of the resized image
@@ -167,6 +173,7 @@ Image objects (like `original` and each object in `resized`) contain the followi
 | `path`      | String  | The path to the image.                                                  |
 | `width`     | Integer | The width of the image.                                                 |
 | `height`    | Integer | The height of the image.                                                |
+| `folderpath`  | String  | Relative path from the image asset folder to the the file (`assets/somefolder/some-file.jpg` => `somefolder`).       |
 | `basename`  | String  | Basename of the file (`assets/some-file.jpg` => `some-file.jpg`).       |
 | `filename`  | String  | Basename without the extension (`assets/some-file.jpg` => `some-file`). |
 | `extension` | String  | Extension of the file (`assets/some-file.jpg` => `jpg`).                |

--- a/lib/jekyll/responsive_image/common.rb
+++ b/lib/jekyll/responsive_image/common.rb
@@ -7,7 +7,7 @@ module Jekyll
         config = ResponsiveImage.defaults.dup.merge(site.config['responsive_image']).merge(:site_dest => site.dest)
 
         # Not very nice, but this is needed to create a clean path to add to keep_files
-        output_dir = format_output_path(config['output_path_format'], '*', '*', '*')
+        output_dir = format_output_path(config['output_path_format'], config['base_path'], '*', '*', '*')
         site.config['keep_files'] << output_dir unless site.config['keep_files'].include?(output_dir)
 
         config

--- a/lib/jekyll/responsive_image/defaults.rb
+++ b/lib/jekyll/responsive_image/defaults.rb
@@ -1,6 +1,7 @@
 module Jekyll
   class ResponsiveImage
     @defaults = {
+      'base_path' => 'assets/images',
       'default_quality'    => 85,
       'output_path_format' => 'assets/resized/%{filename}-%{width}x%{height}.%{extension}',
       'sizes'              => [],

--- a/lib/jekyll/responsive_image/defaults.rb
+++ b/lib/jekyll/responsive_image/defaults.rb
@@ -1,7 +1,7 @@
 module Jekyll
   class ResponsiveImage
     @defaults = {
-      'base_path' => 'assets/images',
+      'base_path' => 'assets',
       'default_quality'    => 85,
       'output_path_format' => 'assets/resized/%{filename}-%{width}x%{height}.%{extension}',
       'sizes'              => [],

--- a/lib/jekyll/responsive_image/image_processor.rb
+++ b/lib/jekyll/responsive_image/image_processor.rb
@@ -10,7 +10,7 @@ module Jekyll
         img = Magick::Image::read(image_path).first
 
         {
-          original: image_hash(image_path, img.columns, img.rows),
+          original: image_hash(image_path, config['base_path'], img.columns, img.rows),
           resized: resize_handler.resize_image(img, config),
         }
       end

--- a/lib/jekyll/responsive_image/resize_handler.rb
+++ b/lib/jekyll/responsive_image/resize_handler.rb
@@ -13,8 +13,8 @@ module Jekyll
 
           next unless needs_resizing?(img, width)
 
-          filepath = format_output_path(config['output_path_format'], img.filename, width, height)
-          resized.push(image_hash(filepath, width, height))
+          filepath = format_output_path(config['output_path_format'], config['base_path'], img.filename, width, height)
+          resized.push(image_hash(filepath, config['base_path'], width, height))
 
           # Don't resize images more than once
           next if File.exists?(filepath)

--- a/lib/jekyll/responsive_image/utils.rb
+++ b/lib/jekyll/responsive_image/utils.rb
@@ -9,13 +9,27 @@ module Jekyll
         result
       end
 
-      def format_output_path(format, path, width, height)
-        params = symbolize_keys(image_hash(path, width, height))
+      def format_output_path(format, basepath, path, width, height)
+        params = symbolize_keys(image_hash(path, basepath, width, height))
         format % params
       end
 
       # Build a hash containing image information
-      def image_hash(path, width, height)
+      def image_hash(path, basepath, width, height)
+
+        if path.start_with?(basepath)
+          folderpath = path.gsub(File.basename(path),"").gsub(basepath,"")
+          if folderpath.slice(0) == "/"
+            folderpath.slice!(0)
+          end
+          if folderpath.slice(folderpath.length-1) == "/"
+            folderpath.slice!(folderpath.length-1)
+          end
+          #folderpath = (folderpath.slice(0,-1) == "/") ? folderpath.slice!(0,-1) : folderpath
+        else
+          folderpath =  ""
+        end
+
         {
           'path'      => path,
           'basename'  => File.basename(path),
@@ -23,6 +37,7 @@ module Jekyll
           'extension' => File.extname(path).delete('.'),
           'width'     => width,
           'height'    => height,
+          'folderpath' => folderpath
         }
       end
     end

--- a/lib/jekyll/responsive_image/version.rb
+++ b/lib/jekyll/responsive_image/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   class ResponsiveImage
-    VERSION = '0.12.0'.freeze
+    VERSION = '0.13.0'.freeze
   end
 end


### PR DESCRIPTION
Proposal for #5 resolution.
It's the first time I code in Ruby so do not hesitate to criticize my code, it's certainly imperfect.

The idea is to configure a base path for images, here : "assets/images". Then, I take the path to the image (example : "assets/images/foldername1/foldername2/myimage.jpg") and trim both the basename and the provided base path, ending with "foldername1/foldername2". I put that in a %{folderpath} for the user to use in the configuration.