### PR TITLE
Destroy the original image when done with resizing

### DIFF
--- a/lib/jekyll/responsive_image/resize_handler.rb
+++ b/lib/jekyll/responsive_image/resize_handler.rb
@@ -35,6 +35,8 @@ module Jekyll
 
           i.destroy!
         end
+        
+        img.destroy!
 
         resized
       end


### PR DESCRIPTION
When re-sizing a bunch of 24 megapixels image (direct from a digital camera) into responsive images, not destroying the `img` member made my server OOM (it does not have a lot of RAM, it's a cheap VPS).

Additionally, when re-generating the site, although there was no need to re-generate the images, it looked like it was still loading them up, and the GC was not kicking in so it was OOM-ing (or close to OOM-ing) as well.

This fixes both issues.