### PR TITLE
rotate resized images based on exif info

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ responsive_image:
     - width: 800
     - width: 1400
       quality: 90
+  
+  # [Optional, Default: false]
+  # Rotate resized images depending on their EXIF rotation attribute. Useful for
+  # working with JPGs directly from digital cameras and smartphones
+  respect_exif_rotation: false
 
   # [Optional, Default: assets]
   # The base directory where assets are stored. This is used to determine the
@@ -128,7 +133,23 @@ You will need to create a template in order to use the `responsive_image` tag. B
     {% endfor %}
 {% endcapture %}
 
-<img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }} /{{ original.path }} {{ original.width }}w">
+<img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}">
+```
+
+#### Responsive image with `srcset` where the largest resized image is the default
+
+> **Note:** This is useful if you don't want your originals to appear on your site. For example, if you're uploading full-res images directly from a device.
+ 
+```twig
+{% capture srcset %}
+    {% for i in resized %}
+        /{{ i.path }} {{ i.width }}w,
+    {% endfor %}
+{% endcapture %}
+
+{% assign largest = resized | sort: 'width' | last %}
+
+<img src="/{{ largest.path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}">
 ```
 
 #### Responsive images with `<picture>`

--- a/lib/jekyll-responsive-image/config.rb
+++ b/lib/jekyll-responsive-image/config.rb
@@ -2,11 +2,12 @@ module Jekyll
   module ResponsiveImage
     class Config
       DEFAULTS = {
-        'default_quality'    => 85,
-        'base_path'          => 'assets',
-        'output_path_format' => 'assets/resized/%{filename}-%{width}x%{height}.%{extension}',
-        'sizes'              => [],
-        'extra_images'       => []
+        'default_quality'       => 85,
+        'base_path'             => 'assets',
+        'output_path_format'    => 'assets/resized/%{filename}-%{width}x%{height}.%{extension}',
+        'sizes'                 => [],
+        'extra_images'          => [],
+        'respect_exif_rotation' => false
       }
 
       def initialize(site)

--- a/lib/jekyll-responsive-image/resize_handler.rb
+++ b/lib/jekyll-responsive-image/resize_handler.rb
@@ -4,6 +4,7 @@ module Jekyll
       include ResponsiveImage::Utils
 
       def resize_image(img, config)
+        img.auto_orient! if config['respect_exif_rotation']
         resized = []
 
         config['sizes'].each do |size|

--- a/lib/jekyll-responsive-image/version.rb
+++ b/lib/jekyll-responsive-image/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module ResponsiveImage
-    VERSION = '1.1.0'.freeze
+    VERSION = '1.1.1'.freeze
   end
 end


### PR DESCRIPTION
EXIF rotation information embedded by the capture device is now
respected when generating output images. Original images remain
untouched.

Not sure of the etiquette so I've added 0.0.1 to the version number (?)