### PR TITLE
Add option to strip EXIF profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ responsive_image:
   # working with JPGs directly from digital cameras and smartphones
   auto_rotate: false
 
+  # [Optional, Default: false]
+  # Strip EXIF and other JPEG profiles. Helps to minimize JPEG size and win friends
+  # at Google PageSpeed.
+  strip: false
+
   # [Optional, Default: assets]
   # The base directory where assets are stored. This is used to determine the
   # `dirname` value in `output_path_format` below.

--- a/features/image-generation.feature
+++ b/features/image-generation.feature
@@ -86,3 +86,34 @@ Feature: Responsive image generation
     When I run Jekyll
     Then the file "_site/assets/resized/exif-rotation-100x50.jpeg" should exist
     Then the file "_site/assets/resized/progressive-100x50.jpeg" should exist
+
+  Scenario: Images should not be stripped of EXIF info by default
+    Given I have a responsive_image configuration with:
+      """
+        template: _includes/responsive-image.html
+        sizes:
+          - width: 100
+      """
+    And I have a file "index.html" with:
+      """
+        {% responsive_image path: assets/exif-rotation.jpeg %}
+      """
+    When I run Jekyll
+    Then the file "_site/assets/resized/exif-rotation-100x50.jpeg" should exist
+    Then the image "_site/assets/resized/exif-rotation-100x50.jpeg" should have an EXIF orientation
+
+  Scenario: Images can be stripped of EXIF info
+    Given I have a responsive_image configuration with:
+      """
+        template: _includes/responsive-image.html
+        sizes:
+          - width: 100
+        strip: true
+      """
+    And I have a file "index.html" with:
+      """
+        {% responsive_image path: assets/exif-rotation.jpeg %}
+      """
+    When I run Jekyll
+    Then the file "_site/assets/resized/exif-rotation-100x50.jpeg" should exist
+    Then the image "_site/assets/resized/exif-rotation-100x50.jpeg" should have no EXIF orientation

--- a/features/step_definitions/jekyll_steps.rb
+++ b/features/step_definitions/jekyll_steps.rb
@@ -65,6 +65,18 @@ Then /^the image "(.+)" should be interlaced$/ do |path|
   img.destroy!
 end
 
+Then /^the image "(.+)" should have an EXIF orientation$/ do |path|
+  img = Magick::Image::read(path).first
+  assert_not_equal img.orientation.to_i, 0
+  img.destroy!
+end
+
+Then /^the image "(.+)" should have no EXIF orientation$/ do |path|
+  img = Magick::Image::read(path).first
+  assert_equal img.orientation.to_i, 0
+  img.destroy!
+end
+
 def write_file(path, contents)
   File.open(path, 'w') do |f|
     f.write(contents)

--- a/lib/jekyll-responsive-image/config.rb
+++ b/lib/jekyll-responsive-image/config.rb
@@ -9,7 +9,8 @@ module Jekyll
         'extra_images'       => [],
         'auto_rotate'        => false,
         'save_to_source'     => true,
-        'cache'              => false
+        'cache'              => false,
+        'strip'              => false
       }
 
       def initialize(site)

--- a/lib/jekyll-responsive-image/resize_handler.rb
+++ b/lib/jekyll-responsive-image/resize_handler.rb
@@ -36,6 +36,9 @@ module Jekyll
 
           Jekyll.logger.info "Generating #{target_filepath}"
 
+          if config['strip']
+            img.strip!
+          end
           i = img.scale(ratio)
           i.write(target_filepath) do |f|
             f.interlace = i.interlace


### PR DESCRIPTION
Implementations of ImageMagick differ in whether or not they strip EXIF profiles by default, so this pull request may not be relevant to all users (then again, it won't hurt either).

This pull request adds an option to call img.strip! before saving the resized image. In my use case, this strips about 15% of the average size of the images on my website. For users of Adobe products that secretly stash a copy of Websters Dictionary in each saved image, the savings would be even greater.

The preservation of EXIF data is hit or miss anyway, so a case could even be made to make strip be true by default. But I'm not sure if there are use cases for EXIF on the web, so I made strip false by default to minimize the risk of surprises.