### PR TITLE
Add condition to extra image generation to only operate on 'files' re…

### DIFF
--- a/features/extra-image-generation.feature
+++ b/features/extra-image-generation.feature
@@ -15,6 +15,25 @@ Feature: Extra image generation
     And the file "_site/assets/resized/everybody-loves-jalapeño-pineapple-cornbread-100x50.png" should exist
     And the file "_site/assets/resized/progressive-100x50.jpeg" should exist
 
+  Scenario: Specifying a recursive glob pattern
+    Given I have a responsive_image configuration with:
+      """
+        sizes:
+          - width: 100
+        extra_images:
+          - assets/**/*
+      """
+    And I have a file "index.html" with "Hello, world!"
+    When I run Jekyll
+    Then the image "assets/resized/everybody-loves-jalapeño-pineapple-cornbread-100x50.png" should have the dimensions "100x50"
+    And the image "assets/resized/exif-rotation-100x50.jpeg" should have the dimensions "100x50"
+    And the image "assets/resized/progressive-100x50.jpeg" should have the dimensions "100x50"
+    And the image "assets/resized/test-100x50.png" should have the dimensions "100x50"
+    And the file "_site/assets/resized/everybody-loves-jalapeño-pineapple-cornbread-100x50.png" should exist
+    And the file "_site/assets/resized/exif-rotation-100x50.jpeg" should exist
+    And the file "_site/assets/resized/progressive-100x50.jpeg" should exist
+    And the file "_site/assets/resized/test-100x50.png" should exist
+
   Scenario: Honouring Jekyll 'source' configuration
     Given I have copied my site to "sub-dir/my-site-copy"
     And I have a configuration with:

--- a/lib/jekyll-responsive-image/extra_image_generator.rb
+++ b/lib/jekyll-responsive-image/extra_image_generator.rb
@@ -2,6 +2,7 @@ module Jekyll
   module ResponsiveImage
     class ExtraImageGenerator < Jekyll::Generator
       include Jekyll::ResponsiveImage::Utils
+      include FileTest
 
       def generate(site)
         config = Config.new(site).to_h
@@ -9,11 +10,13 @@ module Jekyll
 
         config['extra_images'].each do |pathspec|
           Dir.glob(site.in_source_dir(pathspec)) do |image_path|
-            path = Pathname.new(image_path)
-            relative_image_path = path.relative_path_from(site_source)
+            if FileTest.file?(image_path)
+              path = Pathname.new(image_path)
+              relative_image_path = path.relative_path_from(site_source)
 
-            result = ImageProcessor.process(relative_image_path, config)
-            result[:resized].each { |image| keep_resized_image!(site, image) }
+              result = ImageProcessor.process(relative_image_path, config)
+              result[:resized].each { |image| keep_resized_image!(site, image) }
+            end
           end
         end
       end


### PR DESCRIPTION
…turned by the glob


Dir.glob supports recursive wildcard a la `/path/**/*` but the plugin did not support this as it also returns directories