### PR TITLE
resize height on portrait style images and preserve aspect ratio

### DIFF
--- a/jekyll-responsive-image.gemspec
+++ b/jekyll-responsive-image.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'jekyll', ['>= 2.0', "< 4.0"]
   spec.add_runtime_dependency 'rmagick', ['>= 2.0', '< 3.0']
+  spec.add_development_dependency 'pry'
 end

--- a/lib/jekyll-responsive-image/image_processor.rb
+++ b/lib/jekyll-responsive-image/image_processor.rb
@@ -21,7 +21,7 @@ module Jekyll
         begin
           self.new.process(image_path, config)
         rescue SyntaxError
-          nil
+          { original: {}, resized: [] }
         end
       end
     end

--- a/lib/jekyll-responsive-image/image_processor.rb
+++ b/lib/jekyll-responsive-image/image_processor.rb
@@ -18,7 +18,11 @@ module Jekyll
       end
 
       def self.process(image_path, config)
-        self.new.process(image_path, config)
+        begin
+          self.new.process(image_path, config)
+        rescue SyntaxError
+          nil
+        end
       end
     end
   end

--- a/lib/jekyll-responsive-image/renderer.rb
+++ b/lib/jekyll-responsive-image/renderer.rb
@@ -16,12 +16,11 @@ module Jekyll
 
         if result.nil?
           image = ImageProcessor.process(@attributes['path'], config)
-          if image
-            @attributes['original'] = image[:original]
-            @attributes['resized'] = image[:resized]
+          @attributes['original'] = image[:original]
+          @attributes['resized'] = image[:resized]
 
-            @attributes['resized'].each { |resized| keep_resized_image!(@site, resized) }
-          end
+          @attributes['resized'].each { |resized| keep_resized_image!(@site, resized) }
+
           image_template = @site.in_source_dir(@attributes['template'] || config['template'])
           partial = File.read(image_template)
           template = Liquid::Template.parse(partial)

--- a/lib/jekyll-responsive-image/renderer.rb
+++ b/lib/jekyll-responsive-image/renderer.rb
@@ -16,11 +16,12 @@ module Jekyll
 
         if result.nil?
           image = ImageProcessor.process(@attributes['path'], config)
-          @attributes['original'] = image[:original]
-          @attributes['resized'] = image[:resized]
+          if image
+            @attributes['original'] = image[:original]
+            @attributes['resized'] = image[:resized]
 
-          @attributes['resized'].each { |resized| keep_resized_image!(@site, resized) }
-
+            @attributes['resized'].each { |resized| keep_resized_image!(@site, resized) }
+          end
           image_template = @site.in_source_dir(@attributes['template'] || config['template'])
           partial = File.read(image_template)
           template = Liquid::Template.parse(partial)

--- a/lib/jekyll-responsive-image/resize_handler.rb
+++ b/lib/jekyll-responsive-image/resize_handler.rb
@@ -9,9 +9,15 @@ module Jekyll
         resized = []
 
         config['sizes'].each do |size|
-          width = size['width']
-          ratio = width.to_f / img.columns.to_f
-          height = (img.rows.to_f * ratio).round
+          if img.rows > img.columns
+            height = size['width']
+            ratio = height.to_f / img.rows.to_f
+            width = (img.columns.to_f * ratio).round
+          else
+            width = size['width']
+            ratio = width.to_f / img.columns.to_f
+            height = (img.rows.to_f * ratio).round
+          end
 
           next unless needs_resizing?(img, width)
 

--- a/lib/jekyll-responsive-image/resize_handler.rb
+++ b/lib/jekyll-responsive-image/resize_handler.rb
@@ -19,7 +19,7 @@ module Jekyll
             height = (img.rows.to_f * ratio).round
           end
 
-          next unless needs_resizing?(img, width)
+          #next unless needs_resizing?(img, width)
 
           image_path = img.filename.force_encoding(Encoding::UTF_8)
           filepath = format_output_path(config['output_path_format'], config, image_path, width, height)


### PR DESCRIPTION
Typically, when resizing images in a batch format, the preferred outcome is for all images to have their largest dimension scaled down to the new, preferred dimension while preserving the initial image's aspect ratio. 
I've been exploring this plugin in conjunction with a current client site and have discovered that it is currently only capable of resizing images based on their width. 
Imagine we want to resize a batch of images with varying aspect ratios, some portrait (300x900), and others landscape (900x300). The plugin will only catch those images wider than the width parameter(s) specified. At a parameter of 450 for example, all portrait images in this scenario would be skipped.
Whether this is by design for some reason I cannot tell, but if not, then the few lines in this fork would address that issue, allowing the plugin to resize any given image's largest dimension to the newly specified one(s) passed in.