### PR TITLE
MiniMagick

### DIFF
--- a/features/step_definitions/jekyll_steps.rb
+++ b/features/step_definitions/jekyll_steps.rb
@@ -62,26 +62,26 @@ Then /^the file "(.+)" should not exist$/ do |path|
 end
 
 Then /^the image "(.+)" should have the dimensions "(\d+)x(\d+)"$/ do |path, width, height|
-  img = Magick::Image::read(path).first
-  assert_equal "#{width}x#{height}", "#{img.columns}x#{img.rows}"
+  img = MiniMagick::Image.open(path)
+  assert_equal "#{width}x#{height}", "#{img.width}x#{img.height}"
   img.destroy!
 end
 
 Then /^the image "(.+)" should be interlaced$/ do |path|
-  img = Magick::Image::read(path).first
-  assert_equal Magick::JPEGInterlace, img.interlace
+  img = MiniMagick::Image.open(path)
+  assert_equal "JPEG", img.data["interlace"]
   img.destroy!
 end
 
 Then /^the image "(.+)" should have an EXIF orientation$/ do |path|
-  img = Magick::Image::read(path).first
-  assert_not_equal img.orientation.to_i, 0
+  img = MiniMagick::Image.open(path)
+  assert_not_equal img.exif['Orientation'].to_i, 0
   img.destroy!
 end
 
 Then /^the image "(.+)" should have no EXIF orientation$/ do |path|
-  img = Magick::Image::read(path).first
-  assert_equal img.orientation.to_i, 0
+  img = MiniMagick::Image.open(path)
+  assert_equal img.exif['Orientation'].to_i, 0
   img.destroy!
 end
 

--- a/jekyll-responsive-image.gemspec
+++ b/jekyll-responsive-image.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'jekyll', ['>= 2.0', "< 4.0"]
   spec.add_runtime_dependency 'mini_magick', '~> 4.8'
+  spec.add_runtime_dependency 'image_size', '~> 2.0'
 end

--- a/jekyll-responsive-image.gemspec
+++ b/jekyll-responsive-image.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'jekyll', ['>= 2.0', "< 4.0"]
-  spec.add_runtime_dependency 'rmagick', ['>= 2.0', '< 3.0']
+  spec.add_runtime_dependency 'mini_magick', '~> 4.8'
 end

--- a/jekyll-responsive-image.gemspec
+++ b/jekyll-responsive-image.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'jekyll', ['>= 2.0', "< 4.0"]
   spec.add_runtime_dependency 'mini_magick', '~> 4.8'
-  spec.add_runtime_dependency 'image_size', '~> 2.0'
+  spec.add_runtime_dependency 'fastimage', '~> 2.1'
 end

--- a/lib/jekyll-responsive-image.rb
+++ b/lib/jekyll-responsive-image.rb
@@ -3,7 +3,7 @@ require 'yaml'
 
 require 'jekyll'
 require 'mini_magick'
-require 'image_size'
+require 'fastimage'
 
 require 'jekyll-responsive-image/version'
 require 'jekyll-responsive-image/config'

--- a/lib/jekyll-responsive-image.rb
+++ b/lib/jekyll-responsive-image.rb
@@ -3,6 +3,7 @@ require 'yaml'
 
 require 'jekyll'
 require 'mini_magick'
+require 'image_size'
 
 require 'jekyll-responsive-image/version'
 require 'jekyll-responsive-image/config'

--- a/lib/jekyll-responsive-image.rb
+++ b/lib/jekyll-responsive-image.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 require 'yaml'
 
 require 'jekyll'
-require 'rmagick'
+require 'mini_magick'
 
 require 'jekyll-responsive-image/version'
 require 'jekyll-responsive-image/config'

--- a/lib/jekyll-responsive-image/image_processor.rb
+++ b/lib/jekyll-responsive-image/image_processor.rb
@@ -3,6 +3,10 @@ module Jekyll
     class ImageProcessor
       include ResponsiveImage::Utils
 
+      def self.process(image_path, config)
+        self.new.process(image_path, config)
+      end
+
       def process(image_path, config)
         absolute_image_path = File.expand_path(image_path.to_s, config[:site_source])
 
@@ -10,17 +14,31 @@ module Jekyll
 
         resize_handler = ResizeHandler.new
 
-        original_image_width, original_image_height = ImageSize.path(absolute_image_path).size
+        original_image_dimensions = get_dimensions_of_original_image(absolute_image_path, config)
 
         {
-          original: image_hash(config, image_path, original_image_width, original_image_height),
-          resized: resize_handler.resize_image(absolute_image_path, config),
+          original: image_hash(config, image_path, original_image_dimensions.first, original_image_dimensions.last),
+          resized: resize_handler.resize_image(absolute_image_path, original_image_dimensions, config),
         }
       end
 
-      def self.process(image_path, config)
-        self.new.process(image_path, config)
+      private
+
+      def get_dimensions_of_original_image(origina_image_path, config)
+        original_image = FastImage.new(origina_image_path)
+
+        # FastImage – opposed to MiniMagick – takes the image's orientation value into consideration by default when returning the size.
+        # If one is not using the auto_rotate config setting, this needs to be manually 'uncorrected',
+        # so that the resize handler can do its work correctly.
+        return original_image.size.reverse if !config['auto_rotate'] && image_is_rotated_90_degrees?(original_image.orientation)
+
+        original_image.size
       end
+
+      def image_is_rotated_90_degrees?(orientation)
+        [5,6,7,8].include?(orientation)
+      end
+
     end
   end
 end

--- a/lib/jekyll-responsive-image/image_processor.rb
+++ b/lib/jekyll-responsive-image/image_processor.rb
@@ -24,8 +24,8 @@ module Jekyll
 
       private
 
-      def get_dimensions_of_original_image(origina_image_path, config)
-        original_image = FastImage.new(origina_image_path)
+      def get_dimensions_of_original_image(original_image_path, config)
+        original_image = FastImage.new(original_image_path)
 
         # FastImage – opposed to MiniMagick – takes the image's orientation value into consideration by default when returning the size.
         # If one is not using the auto_rotate config setting, this needs to be manually 'uncorrected',

--- a/lib/jekyll-responsive-image/image_processor.rb
+++ b/lib/jekyll-responsive-image/image_processor.rb
@@ -10,21 +10,12 @@ module Jekyll
 
         resize_handler = ResizeHandler.new
 
-        original_image_width, original_image_height = get_dimensions_of_original(absolute_image_path)
+        original_image_width, original_image_height = ImageSize.path(absolute_image_path).size
 
         {
           original: image_hash(config, image_path, original_image_width, original_image_height),
           resized: resize_handler.resize_image(absolute_image_path, config),
         }
-      end
-
-      def get_dimensions_of_original(absolute_image_path)
-        original_image_copy = MiniMagick::Image.open(absolute_image_path)
-        dimensions          = original_image_copy.dimensions
-
-        original_image_copy.destroy!
-
-        dimensions
       end
 
       def self.process(image_path, config)

--- a/lib/jekyll-responsive-image/image_processor.rb
+++ b/lib/jekyll-responsive-image/image_processor.rb
@@ -9,12 +9,22 @@ module Jekyll
         raise SyntaxError.new("Invalid image path specified: #{image_path}") unless File.file?(absolute_image_path)
 
         resize_handler = ResizeHandler.new
-        img = Magick::Image::read(absolute_image_path).first
+
+        original_image_width, original_image_height = get_dimensions_of_original(absolute_image_path)
 
         {
-          original: image_hash(config, image_path, img.columns, img.rows),
-          resized: resize_handler.resize_image(img, config),
+          original: image_hash(config, image_path, original_image_width, original_image_height),
+          resized: resize_handler.resize_image(absolute_image_path, config),
         }
+      end
+
+      def get_dimensions_of_original(absolute_image_path)
+        original_image_copy = MiniMagick::Image.open(absolute_image_path)
+        dimensions          = original_image_copy.dimensions
+
+        original_image_copy.destroy!
+
+        dimensions
       end
 
       def self.process(image_path, config)

--- a/lib/jekyll-responsive-image/resize_handler.rb
+++ b/lib/jekyll-responsive-image/resize_handler.rb
@@ -10,14 +10,14 @@ module Jekyll
           original_image_copy = MiniMagick::Image.open(original_image_path)
           original_image_copy.auto_orient if config['auto_rotate']
 
-          new_width                = size['width']
+          new_width       = size['width']
           downsize_factor = new_width.to_f / original_image_copy.width.to_f
-          new_height               = (original_image_copy.height.to_f * downsize_factor).round
+          new_height      = (original_image_copy.height.to_f * downsize_factor).round
 
           next unless needs_resizing?(original_image_copy, new_width)
 
           image_path = original_image_path.force_encoding(Encoding::UTF_8)
-          filepath = format_output_path(config['output_path_format'], config, image_path, new_width, new_height)
+          filepath   = format_output_path(config['output_path_format'], config, image_path, new_width, new_height)
           resized.push(image_hash(config, filepath, new_width, new_height))
 
           site_source_filepath = File.expand_path(filepath, config[:site_source])


### PR DESCRIPTION
Hi Joseph,

_I’m not sure if this is even desired, but I thought I open a PR anyway. Feel free to close this, if this is not of interest, or not good enough. But here we go:_

I’ve made this gem use the [MiniMagick](https://github.com/minimagick/minimagick) gem instead of the [RMagick](https://github.com/rmagick/rmagick) gem.

**Motivation**

RMagick seems to currently be incompatible with ImageMagick 7. At least most solutions to installing the RMagick gem successfully suggest to explicitly install or downgrade to ImageMagick version 6.
I didn’t want to do that. And MiniMagick did support the latest version. Plus, it claims to have a smaller memory footprint.
And since the underlying library – ImageMagick – is the same with those two gems, I figured it wouldn’t make a difference functionally anyway.

**Explanations**

While changing from the Rmagick to the MiniMagick API, I tried to stay as closely as possible to your original code. I only touched the tests in so far as to accommodate for the different API.

What MiniMagick seems to do differently, though, is handling how to open and save copies of an original image. While with RMagick you passed the opened original around and create a copy on write/save, MiniMagick requires to open the original each time you want to make a resized copy of said original. (At least that’s what I did, following the MiniMagick documentation.)

Now, I don’t know what that did to performance, because I didn’t compare this library with using RMagick and then MiniMagick. But I guess it didn’t improve things in this regard.

**(Partly) Fixing the performance issue**

Regardless, I reckon it was wasteful to always “fully” open the original file, while the `ResizeHandler` is only figuring out if it should create a downsized copy of an image. Because at this stage, it’s only trying to figure out if a file exists at a certain path. None of the actual image needs to be loaded for this.

So that’s why I added another commit that (alas) adds another dependency to the [ImageSize gem](https://github.com/toy/image_size), but in turn gives much greater performance, if – and that’s a big if – you’re _not_ using the `auto_rotate` configuration.

In my case though – a project without `auto_rotate` and close to 2000 original images and ~8000 in total for the _site (I generate 3 versions for each original) – the initial Jekyll build went from ~423 seconds to ~23 seconds. That is for when no new images need to be generated.

I hope that all makes sense! ;-)