### PR TITLE
More permissive rmagick dep

### DIFF
--- a/jekyll-responsive-image.gemspec
+++ b/jekyll-responsive-image.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'jekyll', ['>= 2.0', "< 5.0"]
-  spec.add_runtime_dependency 'rmagick', ['>= 2.0', '< 3.0']
+  spec.add_runtime_dependency 'rmagick', ['>= 2.0', '< 5.0']
 end


### PR DESCRIPTION
RMagick 2.x will no longer compile on Arch Linux because the `libmagick6` is no longer compatible with it.

I've tested this plugin works in my use case at least with RMagic 4.x so this is a simple PR that just relaxes that dependency a little.

Let me know if you'd like me to test anything!