### PR TITLE
Improving build performance when a lot of images have already been resized before

### DIFF
--- a/lib/jekyll-responsive-image/image_processor.rb
+++ b/lib/jekyll-responsive-image/image_processor.rb
@@ -8,12 +8,11 @@ module Jekyll
 
         Jekyll.logger.warn "Invalid image path specified: #{image_path.inspect}" unless File.file?(absolute_image_path)
 
-        resize_handler = ResizeHandler.new
-        img = Magick::Image::read(absolute_image_path).first
+        resize_handler = ResizeHandler.new(absolute_image_path, config)
 
         {
-          original: image_hash(config, image_path, img.columns, img.rows),
-          resized: resize_handler.resize_image(img, config),
+          original: image_hash(config, image_path, resize_handler.original_image.columns, resize_handler.original_image.rows),
+          resized: resize_handler.resize_image,
         }
       end
 

--- a/lib/jekyll-responsive-image/resize_handler.rb
+++ b/lib/jekyll-responsive-image/resize_handler.rb
@@ -13,7 +13,10 @@ module Jekyll
       end
 
       def resize_image
-        @original_image.auto_orient! if @config['auto_rotate']
+        if @config['auto_rotate']
+          load_full_image
+          @original_image.auto_orient!
+        end
 
         resized = []
 
@@ -45,10 +48,7 @@ module Jekyll
 
           Jekyll.logger.info "Generating #{target_filepath}"
 
-          unless @original_image_pixels_loaded
-            @original_image = Magick::Image::read(@original_image_absolute_path).first
-            @original_image_pixels_loaded = true
-          end
+          load_full_image unless @original_image_pixels_loaded
 
           if @config['strip']
             @original_image.strip!
@@ -85,6 +85,11 @@ module Jekyll
 
       def needs_resizing?(width)
         @original_image.columns > width
+      end
+
+      def load_full_image
+        @original_image = Magick::Image::read(@original_image_absolute_path).first
+        @original_image_pixels_loaded = true
       end
 
       def ensure_output_dir_exists!(path)

--- a/lib/jekyll-responsive-image/resize_handler.rb
+++ b/lib/jekyll-responsive-image/resize_handler.rb
@@ -6,18 +6,19 @@ module Jekyll
       attr_reader :original_image
 
       def initialize(original_image_absolute_path, config)
-        @original_image_absolute_path = original_image_absolute_path
-        @original_image = Magick::Image::ping(original_image_absolute_path).first
-        @original_image_pixels_loaded = false
         @config = config
-      end
 
-      def resize_image
+        @original_image_absolute_path = original_image_absolute_path
+
         if @config['auto_rotate']
           load_full_image
           @original_image.auto_orient!
+        else
+          load_image_properties_only
         end
+      end
 
+      def resize_image
         resized = []
 
         @config['sizes'].each do |size|
@@ -90,6 +91,11 @@ module Jekyll
       def load_full_image
         @original_image = Magick::Image::read(@original_image_absolute_path).first
         @original_image_pixels_loaded = true
+      end
+
+      def load_image_properties_only
+        @original_image = Magick::Image::ping(@original_image_absolute_path).first
+        @original_image_pixels_loaded = false
       end
 
       def ensure_output_dir_exists!(path)


### PR DESCRIPTION
Hi @wildlyinaccurate,

This is my suggestion for improving the performance of a Jekyll site build when a lot of the site’s (resized) images have previously already been generated.

[My site](http://photojournal.danielpietzsch.com) takes a lot of time to re-build, although no new images are being generated for the vast majority of those rebuilds: I currently have around 2900 images. And for each of those, 3 additional sizes are generated. A rebuild of that site _without_ any new image-resize operations takes more than 140 seconds. With this modification, it only takes around 14 seconds.

The main thing I did for this was to open the original image using [`.ping`](https://rmagick.github.io/image1.html#ping) instead of `.read`. `.ping` omits the pixel data for the image resulting in a faster read and less memory usage. The full image – including pixel data – is only loaded, when resized versions actually need to be created.

The tests pass.

Hope you like it! :-)

**Update**: Btw, I also did test full rebuilds of my site, generating resized versions of all 2900 images, to make sure it does not worsen that use-case. And the generation time remained between 14 and 15 minutes – as it did before with the master branch.

_All the times listed are for my 2018 MBP 13” 2,3 Ghz Quad-Core i5._