### PR TITLE
Add ignore_extensions option for vectorial files

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ responsive_image:
     - assets/foo/bar.png
     - assets/bgs/*.png
     - assets/avatars/*.{jpeg,jpg}
+
+  # [Optional, Default: []]
+  # File name extensions to ignore when processing the images. It can be used
+  # to avoid processing SVG files.
+  ignore_extensions:
+    - .svg
 ```
 
 ## Troubleshooting

--- a/lib/jekyll-responsive-image/config.rb
+++ b/lib/jekyll-responsive-image/config.rb
@@ -10,7 +10,8 @@ module Jekyll
         'auto_rotate'        => false,
         'save_to_source'     => true,
         'cache'              => false,
-        'strip'              => false
+        'strip'              => false,
+        'ignore_extensions'  => []
       }
 
       def initialize(site)

--- a/lib/jekyll-responsive-image/renderer.rb
+++ b/lib/jekyll-responsive-image/renderer.rb
@@ -15,11 +15,13 @@ module Jekyll
         result = use_cache ? RenderCache.get(cache_key) : nil
 
         if result.nil?
-          image = ImageProcessor.process(@attributes['path'], config)
-          @attributes['original'] = image[:original]
-          @attributes['resized'] = image[:resized]
+          if not config['ignore_extensions'].include? File.extname(@attributes['path'])
+            image = ImageProcessor.process(@attributes['path'], config)
+            @attributes['original'] = image[:original]
+            @attributes['resized'] = image[:resized]
 
-          @attributes['resized'].each { |resized| keep_resized_image!(@site, resized) }
+            @attributes['resized'].each { |resized| keep_resized_image!(@site, resized) }
+          end
 
           image_template = @site.in_source_dir(@attributes['template'] || config['template'])
           partial = File.read(image_template)


### PR DESCRIPTION
When using SVG files the plugin is very slow processing them and it would be best to use the original SVG file anyways.

I could avoid using this plugin for vectorial images but then migrating from bitmap to vectorial involves changing template logic making it harder. Also, images get mixed and it may be hard to notice when rescaling is being done in the wrong files.

I think it's easier to have the plugin be able to bypass processing vectorial images and just invoke the template with the original file path.

Thanks for your time.

PD: I'm new to Ruby, these are almost my first lines of code besides some basic Jekyll plugin.