### PR TITLE
Removing "Troubleshooting" section regarding incompatibilty with ImageMagick 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,23 +194,6 @@ responsive_image:
     - assets/avatars/*.{jpeg,jpg}
 ```
 
-## Troubleshooting
-
-### Error: Can't install RMagick
-
-`jekyll-responsive-image` uses `rmagick` which is currently incompatible with ImageMagick 7. If you get an error like:
-
-```
-Can't install RMagick 2.16.0. Can't find MagickWand.h
-```
-
-Then you will need to install ImageMagick 6. If you are using Homebrew on Mac OS, this can be done with the following commands:
-
-```
-$ brew uninstall imagemagick
-$ brew install imagemagick@6 && brew link imagemagick@6 --force
-```
-
 ## Caching
 
 You may be able to speed up the build of large sites by enabling render caching. This is usually only effective when the same image is used many times, for example a header image that is rendered in every post.


### PR DESCRIPTION
rmagick >= 4.1.0 is compatible with version 7 of ImageMagick, which makes this section of the README redundant.

I decided to remove this hint altogether, since I believe this to be a rare edge case after rmagick has been updated (and this Gemspec allows for a IM7-compatible rmagick version to be installed). I am successfully using this gem with ImageMagick 7 and rmagick 4.3.

Related PR: https://github.com/wildlyinaccurate/jekyll-responsive-image/pull/80
Related Issue: https://github.com/wildlyinaccurate/jekyll-responsive-image/issues/108